### PR TITLE
Add CODEOWNERS for sole repository ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Global code ownership
+# This makes @stoberman37 the sole code owner for all files.
+* @stoberman37


### PR DESCRIPTION
## Summary
Add a repository-wide CODEOWNERS file assigning ownership of all paths to @stoberman37.

## Changes
- Add `.github/CODEOWNERS`
- Set global ownership rule: `* @stoberman37`

## Why
This enables branch protection rules that require code owner review while allowing owner-specific bypass configuration in GitHub rulesets.